### PR TITLE
This pull request introduces several API improvements to the StateMachineLib, focusing on developer experience and consistency, along with corresponding tests.

### DIFF
--- a/Runtime/StateGraph.cs
+++ b/Runtime/StateGraph.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Nopnag.StateMachineLib
@@ -9,9 +10,19 @@ namespace Nopnag.StateMachineLib
     StateUnit _currentUnit;
     readonly List<StateUnit> _units = new();
 
+    [Obsolete("Use CreateState() instead. If a name is needed, it should be managed by the user externally or via StateUnit properties if available.", false)]
     public StateUnit CreateUnit(string name)
     {
       var stateUnit = new StateUnit(name, this);
+      _units.Add(stateUnit);
+      if (InitialUnit == null) InitialUnit = stateUnit;
+
+      return stateUnit;
+    }
+
+    public StateUnit CreateState()
+    {
+      var stateUnit = new StateUnit(this);
       _units.Add(stateUnit);
       if (InitialUnit == null) InitialUnit = stateUnit;
 


### PR DESCRIPTION
**Body:**

This pull request introduces several API improvements to the StateMachineLib, focusing on developer experience and consistency, along with corresponding tests.

**Key Changes:**

**API Enhancements (`Runtime/`):**

*   **`StateUnit`:**
    *   Added public synonym properties (e.g., `OnEnter`, `OnUpdate`, `OnFixedUpdate`, `OnLateUpdate`, `OnUpdateBeforeTransitionCheck`) for the action delegate fields. The original fields (e.g., `EnterStateFunction`) are now marked as `[Obsolete]`.
    *   Introduced `On<T>()` synonym methods for `Listen<T>()` (for EventBus events) and `ListenSignal<T>()` (for C# `Action` signals). The original `Listen()` and `ListenSignal()` methods are now marked as `[Obsolete]`.
    *   Lifecycle methods (`Start`, `Update`, `FixedUpdate`, `LateUpdate`, `CheckTransitions`, `Exit`) and the `IsActive()` helper method have been made `internal` to better encapsulate `StateUnit`'s internal logic.
*   **`StateGraph`:**
    *   Introduced `CreateState()` as the new preferred method for instantiating `StateUnit` objects.
    *   The older `CreateUnit(string name)` method is now marked as `[Obsolete]`.
*   **General:**
    *   Ensured `using System;` is present in `StateGraph.cs` to correctly resolve the `[Obsolete]` attribute.

**Testing (`Tests/`):**

*   Added a new suite of tests in `StateMachineTests.cs` specifically for the new preferred API surface, including:
    *   State creation using `StateGraph.CreateState()`.
    *   Assigning state logic via `StateUnit.OnEnter`, `StateUnit.OnUpdate`, `StateUnit.OnExit`.
    *   Event and signal listening using `StateUnit.On<T>(...)` for both EventBus events (with and without `EventQuery`) and C# `Action` signals.
*   Corrected the usage of `EventQuery` in the new tests to align with `EventBusLib`'s parameter-based filtering (using `IParameter` instances).
*   Existing tests remain in place to ensure the deprecated API paths continue to function as expected, providing backward compatibility.

**Documentation (`README.md`):**

*   The `README.md` has been comprehensively updated to:
    *   Reflect all API changes.
    *   Clearly indicate deprecated methods/properties and their new preferred synonyms.
    *   Update code examples to use the new API style.
    *   Explain the usage of `StateGraph.CreateState()` and the implications for state naming.

These changes aim to make the library more intuitive to use while maintaining functionality for existing integrations.
