### PR TITLE
feat: Introduce CreateManagedStateMachine for simplified MonoBehaviou…

### DIFF
--- a/Runtime/MonoBehaviourExtensions.cs
+++ b/Runtime/MonoBehaviourExtensions.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace Nopnag.StateMachineLib // Assuming StateMachine and StateMachineWrapper are in this namespace
+{
+    public static class MonoBehaviourExtensions
+    {
+        /// <summary>
+        /// Creates a new StateMachine instance whose lifecycle (Start, Update, Exit) 
+        /// is automatically managed and tied to this MonoBehaviour.
+        /// - The StateMachine will automatically receive Update, FixedUpdate, and LateUpdate calls.
+        /// - It will automatically Start when the MonoBehaviour is active and updates begin.
+        /// - It will pause updates if the MonoBehaviour is disabled.
+        /// - It will automatically call Exit() on the StateMachine when the MonoBehaviour is destroyed.
+        /// </summary>
+        /// <param name="mb">The MonoBehaviour to link the StateMachine's lifecycle to.</param>
+        /// <returns>A new StateMachine instance that is lifecycle-managed.</returns>
+        public static StateMachine CreateManagedStateMachine(this MonoBehaviour mb)
+        {
+            // StateMachineWrapper's constructor subscribes to ManualEventManager,
+            // which keeps the wrapper instance alive even if this local 'wrapper' variable goes out of scope.
+            // The wrapper will self-dispose when 'mb' is destroyed.
+            var wrapper = new StateMachineWrapper(mb);
+            return wrapper.StateMachine;
+        }
+    }
+} 

--- a/Runtime/MonoBehaviourExtensions.cs.meta
+++ b/Runtime/MonoBehaviourExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 757c799e2a9ac4158b716ff5f126c69d

--- a/Runtime/StateMachine.cs
+++ b/Runtime/StateMachine.cs
@@ -5,6 +5,7 @@ namespace Nopnag.StateMachineLib
   public class StateMachine
   {
     public readonly List<StateGraph> GraphList = new();
+    private bool _isStarted = false;
 
     public StateGraph CreateGraph()
     {
@@ -16,15 +17,24 @@ namespace Nopnag.StateMachineLib
     public void Exit()
     {
       for (var i = 0; i < GraphList.Count; i++) GraphList[i].ExitGraph();
+      _isStarted = false;
     }
 
     public void FixedUpdateMachine()
     {
+      if (!_isStarted)
+      {
+        Start();
+      }
       for (var i = 0; i < GraphList.Count; i++) GraphList[i].FixedUpdateGraph();
     }
 
     public void LateUpdateMachine()
     {
+      if (!_isStarted)
+      {
+        Start();
+      }
       for (var i = 0; i < GraphList.Count; i++) GraphList[i].LateUpdateGraph();
     }
 
@@ -35,11 +45,19 @@ namespace Nopnag.StateMachineLib
 
     public void Start()
     {
-      for (var i = 0; i < GraphList.Count; i++) GraphList[i].EnterGraph();
+      if (!_isStarted)
+      {
+        for (var i = 0; i < GraphList.Count; i++) GraphList[i].EnterGraph();
+        _isStarted = true;
+      }
     }
 
     public void UpdateMachine()
     {
+      if (!_isStarted)
+      {
+        Start();
+      }
       for (var i = 0; i < GraphList.Count; i++) GraphList[i].UpdateGraph();
     }
   }

--- a/Runtime/StateMachineWrapper.cs
+++ b/Runtime/StateMachineWrapper.cs
@@ -1,0 +1,91 @@
+using Nopnag.StateMachineLib;
+using System;
+using UnityEngine;
+
+public class StateMachineWrapper : IDisposable
+{
+    public StateMachine StateMachine { get; private set; }
+    MonoBehaviour _monitoredBehaviour;
+    bool _isDisposed = false;
+
+    public StateMachineWrapper(MonoBehaviour behaviourToMonitor)
+    {
+        if (behaviourToMonitor == null)
+        {
+            throw new ArgumentNullException(nameof(behaviourToMonitor), "Monitored MonoBehaviour cannot be null.");
+        }
+
+        _monitoredBehaviour = behaviourToMonitor;
+        StateMachine = new StateMachine();
+
+        if (ManualEventManager.Instance != null)
+        {
+            ManualEventManager.Instance.OnUpdate += HandleUnityUpdate;
+            ManualEventManager.Instance.OnFixedUpdate += HandleUnityFixedUpdate;
+            ManualEventManager.Instance.OnLateUpdate += HandleUnityLateUpdate;
+        }
+        else
+        {
+            Debug.LogError("StateMachineWrapper: ManualEventManager.Instance is null. Automatic updates will not occur.", _monitoredBehaviour);
+        }
+    }
+
+    void HandleUnityUpdate() => ProcessStateMachineUpdates(() => StateMachine?.UpdateMachine());
+    void HandleUnityFixedUpdate() => ProcessStateMachineUpdates(() => StateMachine?.FixedUpdateMachine());
+    void HandleUnityLateUpdate() => ProcessStateMachineUpdates(() => StateMachine?.LateUpdateMachine());
+
+    void ProcessStateMachineUpdates(Action stateMachineUpdateAction)
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        // Check if the MonoBehaviour has been destroyed
+        // A Unity object becomes "fake null" when destroyed.
+        if (_monitoredBehaviour == null || !_monitoredBehaviour) 
+        {
+            CleanupAndDispose();
+            return;
+        }
+
+        // Check if the MonoBehaviour is disabled
+        if (!_monitoredBehaviour.enabled)
+        {
+            // If it was started, it's now effectively "paused".
+            // If it was disabled before ever being started, _isStarted remains false.
+            return;
+        }
+
+        // MonoBehaviour is alive and enabled
+        stateMachineUpdateAction?.Invoke(); 
+    }
+    
+    void CleanupAndDispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+        _isDisposed = true;
+
+        StateMachine?.Exit(); 
+
+        if (ManualEventManager.Instance != null)
+        {
+            ManualEventManager.Instance.OnUpdate -= HandleUnityUpdate;
+            ManualEventManager.Instance.OnFixedUpdate -= HandleUnityFixedUpdate;
+            ManualEventManager.Instance.OnLateUpdate -= HandleUnityLateUpdate;
+        }
+
+        StateMachine = null; 
+        _monitoredBehaviour = null;
+        // Debug.Log("StateMachineWrapper disposed."); // Optional: for debugging
+    }
+
+    public void Dispose()
+    {
+        CleanupAndDispose();
+        // GC.SuppressFinalize(this); // Only if a finalizer is added, which is not currently planned.
+    }
+} 

--- a/Runtime/StateMachineWrapper.cs.meta
+++ b/Runtime/StateMachineWrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fbf9999ba6cd7488b9a826d6b552150f

--- a/Runtime/Util/ManualEventManager.cs
+++ b/Runtime/Util/ManualEventManager.cs
@@ -1,0 +1,39 @@
+using System;
+using UnityEngine;
+
+public class ManualEventManager : MonoBehaviour
+{
+  public event Action OnUpdate;
+  public event Action OnLateUpdate;
+  public event Action OnFixedUpdate;
+
+  static ManualEventManager _instance;
+  public static ManualEventManager Instance {
+    get
+    {
+      if (_instance == null)
+      {
+        _instance = new GameObject("ManualEventManager").AddComponent<ManualEventManager>();
+      }
+      return _instance;
+    }
+  }
+            
+  void Awake()
+  {
+    DontDestroyOnLoad(this);
+  }
+            
+  void Update()
+  {
+    OnUpdate?.Invoke();
+  }
+  void LateUpdate()
+  {
+    OnLateUpdate?.Invoke();
+  }
+  void FixedUpdate()
+  {
+    OnFixedUpdate?.Invoke();
+  }
+}

--- a/Runtime/Util/ManualEventManager.cs.meta
+++ b/Runtime/Util/ManualEventManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 58bd3414eda84d8db693d71f4d5d0edb
+timeCreated: 1747327961


### PR DESCRIPTION
## PR: Introduce `CreateManagedStateMachine` for Simplified MonoBehaviour Integration

**Summary:**

This pull request introduces a new extension method, `CreateManagedStateMachine(this MonoBehaviour mb)`, to simplify the integration of the StateMachineLib with Unity's `MonoBehaviour` lifecycle. This change aims to provide a more intuitive and streamlined API for users, abstracting away the underlying `StateMachineWrapper` and `ManualEventManager` components.

**Key Changes:**

*   **New Extension Method:**
    *   Added `Runtime/MonoBehaviourExtensions.cs` containing the `public static StateMachine CreateManagedStateMachine(this MonoBehaviour mb)` extension method.
    *   This method handles the instantiation of a `StateMachine` and its internal `StateMachineWrapper`, automatically linking the state machine's lifecycle (Start, Update, Exit) to the MonoBehaviour's lifecycle events (enabled, disabled, destroyed).

*   **`StateMachineWrapper` as an Internal Detail:**
    *   `Runtime/StateMachineWrapper.cs` is now primarily an internal implementation detail used by the `CreateManagedStateMachine` extension.

*   **Updated Tests:**
    *   All relevant tests in `Tests/StateMachineTests.cs` (specifically the `StateMachineWrapper` tests) have been updated to use the new `mb.CreateManagedStateMachine()` syntax, ensuring the new API is well-tested.

*   **Revised `StateMachine.cs` Behavior:**
    *   `StateMachine.Start()` now prevents re-initialization if already started.
    *   `StateMachine.UpdateMachine()`, `FixedUpdateMachine()`, and `LateUpdateMachine()` will now automatically call `Start()` if the state machine hasn't been started yet.
    *   `StateMachine.Exit()` now resets the "started" status.

*   **Documentation Updates (`README.md`):**
    *   The "Simplified MonoBehaviour Integration" section has been rewritten to feature `CreateManagedStateMachine()` as the primary and recommended way to link a state machine to a `MonoBehaviour`.
    *   The "Practical Usage Example (Character Controller)" has been updated to use `CreateManagedStateMachine()`, removing manual lifecycle management calls.
    *   References to direct `StateMachineWrapper` usage by the end-user have been minimized, and it's now mentioned as an internal helper.
    *   The "Installation" and "Practical Usage Example (Character Controller)" sections have been moved to the end of the `README.md` for better flow.

**Benefits:**

*   **Simplified API:** Users can now create and manage a `StateMachine` tied to a `MonoBehaviour` with a single line of code: `var sm = CreateManagedStateMachine();`.
*   **Improved Encapsulation:** The complexities of `StateMachineWrapper` and `ManualEventManager` are hidden from the end-user, leading to a cleaner and easier-to-understand interface.
*   **Reduced Boilerplate:** Less manual setup is required to integrate the state machine with `MonoBehaviour` lifecycle events.
*   **Enhanced Readability:** Code using the state machine will be more concise and focused on state logic rather than lifecycle management.

**How to Test:**

The existing tests in `Tests/StateMachineTests.cs`, particularly those previously testing `StateMachineWrapper` directly, now serve as tests for the `CreateManagedStateMachine()` functionality. Running these tests will validate the correct behavior of the managed lifecycle.