### PR TITLE
Test/component enable disable event subscriptions

### DIFF
--- a/Tests/StateMachineTests.cs
+++ b/Tests/StateMachineTests.cs
@@ -1362,6 +1362,77 @@ namespace Nopnag.StateMachineLib.Tests
     }
 
     [UnityTest]
+    public IEnumerator StateMachineWrapper_ComponentDisabledEnabled_EventSubscriptionsPersist()
+    {
+      ResetWrapperTestFlags();
+      
+      // Create GameObject with MonoBehaviour
+      var go = new GameObject("TestEventSubscription");
+      var mb = go.AddComponent<TestMonoBehaviourForWrapper>();
+      mb.enabled = true;
+
+      // Create managed StateMachine
+      var sm = mb.CreateManagedStateMachine();
+      var graph = sm.CreateGraph();
+      var idleState = graph.CreateState();
+      graph.InitialUnit = idleState;
+
+      // Track event calls
+      int eventCallCount = 0;
+      idleState.OnEnter = () => Debug.Log("Idle State Entered");
+      idleState.On<TestEvent>(@event => 
+      {
+        eventCallCount++;
+        Debug.Log($"TestEvent received while component enabled={mb.enabled}, eventCallCount={eventCallCount}");
+      });
+
+      yield return null; // Frame 1: State enters, subscription active
+
+      // Raise event while enabled
+      EventBus.Raise(new TestEvent());
+      sm.UpdateMachine(); // Process event
+      Assert.AreEqual(1, eventCallCount, "Event should be received while component is enabled");
+
+      // Disable component
+      mb.enabled = false;
+      yield return null; // Frame 2: Component disabled, SM paused
+
+      // Raise event while disabled
+      EventBus.Raise(new TestEvent());
+      yield return null;
+      Assert.AreEqual(1, eventCallCount, "Event should NOT be received while component is disabled (IsActive=false)");
+
+      // Re-enable component
+      mb.enabled = true;
+      yield return null; // Frame 3: Component re-enabled
+
+      // Raise event after re-enable
+      EventBus.Raise(new TestEvent());
+      sm.UpdateMachine(); // Process event
+      Assert.AreEqual(2, eventCallCount, "Event should be received again after component is re-enabled");
+
+      // Disable again
+      mb.enabled = false;
+      yield return null;
+
+      // Raise event while disabled again
+      EventBus.Raise(new TestEvent());
+      yield return null;
+      Assert.AreEqual(2, eventCallCount, "Event should still NOT be received while disabled");
+
+      // Re-enable again
+      mb.enabled = true;
+      yield return null;
+
+      // Raise event after second re-enable
+      EventBus.Raise(new TestEvent());
+      sm.UpdateMachine();
+      Assert.AreEqual(3, eventCallCount, "Event should be received after second re-enable");
+
+      Object.DestroyImmediate(go);
+    }
+
+    [UnityTest]
     public IEnumerator StateMachineWrapper_OnExit_AccessesDestroyedChildObject_ShouldNotThrowException()
     {
       ResetWrapperTestFlags();


### PR DESCRIPTION
## Fix: Pause StateMachine on Component Disable/GameObject Inactive

### Problem
Event callbacks were still executing when component was disabled or GameObject was inactive.

### Solution
Added `OnEnable()`/`OnDisable()` hooks to control StateMachine power:
- **Disabled/Inactive** → Power OFF → No updates, no event callbacks
- **Enabled/Active** → Power ON → Updates and events work
- **State preserved** (no Exit called)

### Changes
- Added `OnEnable()` / `OnDisable()` to `StateMachineWrapper`
- Power control via `SetTurnedOn()` based on component/GameObject state
- Added 2 tests verifying pause/resume with events

### Tests
- `StateMachineWrapper_ComponentDisabledEnabled_EventSubscriptionsPersist`
- `StateMachineWrapper_GameObjectSetActive_PausesStateMachine`

Both passing ✅