### PR TITLE
Fix: Prevent premature OnEnable from interfering with StateMachine in…

### DIFF
--- a/Runtime/StateMachineWrapper.cs
+++ b/Runtime/StateMachineWrapper.cs
@@ -9,6 +9,9 @@ public class StateMachineWrapper : MonoBehaviour
     // Dictionary: MonoBehaviour -> StateMachine mapping
     private Dictionary<MonoBehaviour, StateMachine> _managedStateMachines = new();
     
+    // Track if OnEnable was called (to differentiate first creation vs re-enable)
+    private bool _hasBeenDisabled = false;
+    
     /// <summary>
     /// Gets or creates the StateMachineWrapper component on the given GameObject.
     /// </summary>
@@ -61,16 +64,22 @@ public class StateMachineWrapper : MonoBehaviour
     
     void OnEnable()
     {
-        // When wrapper becomes enabled (GameObject active or component enabled)
-        // Turn on power for all managed state machines
-        UpdateAllStateMachinesPower(true);
+        // Only restore power if this is a re-enable (not first creation)
+        // This prevents interfering with StateMachine initialization
+        if (_hasBeenDisabled)
+        {
+            // Turn on power for all managed state machines
+            UpdateAllStateMachinesPower(turnOn: true);
+        }
     }
     
     void OnDisable()
     {
-        // When wrapper becomes disabled (GameObject inactive or component disabled)
+        // Mark that we've been disabled (so next OnEnable should restore power)
+        _hasBeenDisabled = true;
+        
         // Turn off power for all managed state machines (pause without Exit)
-        UpdateAllStateMachinesPower(false);
+        UpdateAllStateMachinesPower(turnOn: false);
     }
     
     void UpdateAllStateMachinesPower(bool turnOn)


### PR DESCRIPTION
Problem: OnEnable() was being called immediately when StateMachineWrapper was created as a MonoBehaviour, causing it to try to manage StateMachine power before the StateMachine had been properly initialized via Start(). This led to events raised during initialization being missed because CurrentUnit was still null.

Solution: Introduced _hasBeenDisabled flag that tracks whether the wrapper has been disabled at least once. OnEnable() now only restores power if _hasBeenDisabled is true, preventing it from interfering with newly created StateMachines that haven't been Started yet.

Added test StateMachineWrapper_EventRaisedBeforeFirstUpdate_WorksCorrectly to verify that events raised before first Update are correctly ignored (not processed until after Start), and events raised after Start work as expected.