### PR TITLE
Test/component enable disable event subscriptions

### DIFF
--- a/Runtime/MonoBehaviourExtensions.cs
+++ b/Runtime/MonoBehaviourExtensions.cs
@@ -1,27 +1,23 @@
+using System;
 using UnityEngine;
 
-namespace Nopnag.StateMachineLib // Assuming StateMachine and StateMachineWrapper are in this namespace
+namespace Nopnag.StateMachineLib
 {
     public static class MonoBehaviourExtensions
     {
         /// <summary>
-        /// Creates a new StateMachine instance whose lifecycle (Start, Update, Exit) 
-        /// is automatically managed and tied to this MonoBehaviour.
-        /// - The StateMachine will automatically receive Update, FixedUpdate, and LateUpdate calls.
-        /// - It will automatically Start when the MonoBehaviour is active and updates begin.
-        /// - It will pause updates if the MonoBehaviour is disabled.
-        /// - It will automatically call Exit() on the StateMachine when the MonoBehaviour (or its GameObject) is destroyed.
-        /// - Multiple MonoBehaviours on the same GameObject can each have their own managed StateMachine.
+        /// Creates a new StateMachine instance whose lifecycle is automatically managed.
+        /// The setup callback allows you to configure the StateMachine (create graphs, states, transitions).
+        /// The StateMachine will be automatically started after the callback completes, ensuring
+        /// that event transitions work immediately (even in Awake).
         /// </summary>
         /// <param name="mb">The MonoBehaviour to link the StateMachine's lifecycle to.</param>
-        /// <returns>A new StateMachine instance that is lifecycle-managed.</returns>
-        public static StateMachine CreateManagedStateMachine(this MonoBehaviour mb)
+        /// <param name="setupCallback">Callback to configure the StateMachine</param>
+        /// <returns>A new StateMachine instance that is lifecycle-managed and started.</returns>
+        public static StateMachine CreateManagedStateMachine(this MonoBehaviour mb, Action<StateMachine> setupCallback)
         {
-            // Get or create the wrapper component on this GameObject
             var wrapper = StateMachineWrapper.GetOrCreate(mb.gameObject);
-            
-            // Create and register a new StateMachine for this MonoBehaviour
-            return wrapper.CreateStateMachineFor(mb);
+            return wrapper.CreateStateMachineFor(mb, setupCallback);
         }
     }
 } 

--- a/Runtime/StateMachineWrapper.cs
+++ b/Runtime/StateMachineWrapper.cs
@@ -13,11 +13,15 @@ public class StateMachineWrapper : MonoBehaviour
 
   /// <summary>
   /// Creates and registers a new StateMachine for the given MonoBehaviour owner.
+  /// The setup callback is invoked immediately, and then the StateMachine is started automatically.
   /// </summary>
-  public StateMachine CreateStateMachineFor(MonoBehaviour owner)
+  public StateMachine CreateStateMachineFor(MonoBehaviour owner, Action<StateMachine> setupCallback)
   {
     if (owner == null)
       throw new ArgumentNullException(nameof(owner));
+    
+    if (setupCallback == null)
+      throw new ArgumentNullException(nameof(setupCallback));
 
     if (_managedStateMachines.ContainsKey(owner))
     {
@@ -29,6 +33,14 @@ public class StateMachineWrapper : MonoBehaviour
 
     var sm = new StateMachine();
     _managedStateMachines[owner] = sm;
+    
+    // Allow user to set up the StateMachine
+    setupCallback(sm);
+    
+    // Start the StateMachine immediately after setup
+    // This ensures event transitions work right away (even in Awake)
+    sm.Start();
+    
     return sm;
   }
 

--- a/Runtime/StateMachineWrapper.cs
+++ b/Runtime/StateMachineWrapper.cs
@@ -10,6 +10,8 @@ public class StateMachineWrapper : MonoBehaviour
   bool _hasBeenDisabled = false;
   // Dictionary: MonoBehaviour -> StateMachine mapping
   Dictionary<MonoBehaviour, StateMachine> _managedStateMachines = new();
+  // Track which StateMachines haven't been Started yet (created while owner was disabled)
+  HashSet<StateMachine> _pendingStartStateMachines = new();
 
   /// <summary>
   /// Creates and registers a new StateMachine for the given MonoBehaviour owner.
@@ -37,9 +39,18 @@ public class StateMachineWrapper : MonoBehaviour
     // Allow user to set up the StateMachine
     setupCallback(sm);
     
-    // Start the StateMachine immediately after setup
-    // This ensures event transitions work right away (even in Awake)
-    sm.Start();
+    // Only Start the StateMachine if the owner MonoBehaviour is currently enabled
+    // If disabled, Start will be deferred until OnEnable
+    if (owner.enabled && owner.gameObject.activeInHierarchy)
+    {
+      sm.Start();
+    }
+    else
+    {
+      // Mark as pending start (will be started when owner becomes enabled)
+      _pendingStartStateMachines.Add(sm);
+      sm.SetTurnedOn(false);
+    }
     
     return sm;
   }
@@ -79,11 +90,22 @@ public class StateMachineWrapper : MonoBehaviour
       }
 
       _managedStateMachines.Remove(owner);
+      _pendingStartStateMachines.Remove(sm); // Clean up pending start tracking
     }
   }
 
   void OnEnable()
   {
+    // Start any StateMachines that were created while their owner was disabled
+    if (_pendingStartStateMachines.Count > 0)
+    {
+      foreach (var sm in _pendingStartStateMachines)
+      {
+        sm.Start();
+      }
+      _pendingStartStateMachines.Clear();
+    }
+    
     // Only restore power if this is a re-enable (not first creation)
     // This prevents interfering with StateMachine initialization
     if (_hasBeenDisabled)

--- a/Tests/GraphHostDetachAttachTests.cs
+++ b/Tests/GraphHostDetachAttachTests.cs
@@ -40,14 +40,18 @@ namespace Nopnag.StateMachineLib.Tests
     // Event tracking flags
     bool _detachEventReceived;
     bool _attachEventReceived;
+#pragma warning disable CS0414
     bool _timerEventReceived;
+#pragma warning restore CS0414
     int _eventCallCount;
     string _lastEventMessage;
 
     // State lifecycle tracking
     bool _detachState1Entered, _detachState1Updated, _detachState1Exited;
+#pragma warning disable CS0414
     bool _detachState2Entered, _detachState2Updated, _detachState2Exited;
     bool _detachState3Entered, _detachState3Updated, _detachState3Exited;
+#pragma warning restore CS0414
     int _detachState1UpdateCount, _detachState2UpdateCount;
     float _detachState1UpdateTime, _detachState2UpdateTime;
 
@@ -528,8 +532,10 @@ namespace Nopnag.StateMachineLib.Tests
       var subState2 = subGraph.CreateState();
       subGraph.InitialUnit = subState1;
 
+#pragma warning disable CS0219
       bool subState1Entered = false;
       bool subState2Entered = false;
+#pragma warning restore CS0219
       subState1.OnEnter = () => subState1Entered = true;
       subState2.OnEnter = () => subState2Entered = true;
 
@@ -707,7 +713,9 @@ namespace Nopnag.StateMachineLib.Tests
     public IEnumerator DetachedGraph_DoesNotReceiveStateMachineLocalEvents()
     {
       // Setup listeners on both graphs
+#pragma warning disable CS0219
       bool mainGraphEventReceived = false;
+#pragma warning restore CS0219
       bool detachableGraphEventReceived = false;
 
       _mainState1.On<TestAttachEvent>(evt => mainGraphEventReceived = true);
@@ -739,7 +747,9 @@ namespace Nopnag.StateMachineLib.Tests
     [UnityTest]
     public IEnumerator DetachedGraph_CannotSendLocalEvents()
     {
+#pragma warning disable CS0219
       bool mainGraphEventReceived = false;
+#pragma warning restore CS0219
       _mainState1.On<TestDetachEvent>(evt => mainGraphEventReceived = true);
 
       _stateMachine.Start();

--- a/Tests/PoweredNodeTests.cs
+++ b/Tests/PoweredNodeTests.cs
@@ -5,10 +5,12 @@ namespace Nopnag.StateMachineLib.Tests
 {
   public class PoweredNodeTests
   {
+#pragma warning disable CS8618 // Non-nullable field must contain non-null value when exiting constructor
     PoweredNode _childNode;
     PoweredNode _grandChildNode;
     PoweredNode _parentNode;
     PoweredNode _powerSource;
+#pragma warning restore CS8618
 
     [Test]
     public void Child_GetsPowerFromActiveParent()
@@ -246,10 +248,12 @@ namespace Nopnag.StateMachineLib.Tests
     [TearDown]
     public void Teardown()
     {
-      _powerSource    = null;
-      _parentNode     = null;
-      _childNode      = null;
-      _grandChildNode = null;
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type
+      _powerSource    = null!;
+      _parentNode     = null!;
+      _childNode      = null!;
+      _grandChildNode = null!;
+#pragma warning restore CS8625
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.nopnag.statemachinelib",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "displayName": "Nopnag State Machine",
   "description": "A state machine implementation for Unity with support for hierarchical graphs, dynamic management, and local events.",
   "unity": "6000.1", 


### PR DESCRIPTION
## v2.0.0 - Component Lifecycle & Event Subscription Fixes

### 💥 Breaking Changes
**API Change**: `CreateManagedStateMachine()` now requires a setup callback

```csharp
// Before (v1.x)
var sm = this.CreateManagedStateMachine();
var graph = sm.CreateGraph();

// After (v2.0.0)
this.CreateManagedStateMachine(sm => {
    var graph = sm.CreateGraph();
    // setup...
});
```

### ✨ What's Fixed
- **Event Timing**: StateMachines now correctly receive events raised in `Awake()` immediately after creation
- **Component Lifecycle**: Properly handles initially-disabled MonoBehaviours - defers `Start()` until component is enabled
- **Power Management**: StateMachines pause when component disabled or GameObject inactive, resume on re-enable
- **Disposal Test**: Updated to use new callback-based API

### 🔧 Technical Details
- Added `_pendingStartStateMachines` tracking for deferred initialization
- `CreateStateMachineFor` now checks `owner.enabled` before calling `Start()`
- `OnEnable` processes pending Start calls before restoring power
- Ensures `StateMachine.IsActive` and `CurrentUnit` are valid before event processing

### 📚 Documentation
- Updated README with new API usage examples
- Added important notes about automatic `Start()` behavior
- Version bumped to 2.0.0 (breaking change)