### PR TITLE
Fix/event transition chaining

### DIFF
--- a/Runtime/Transition/TransitionByEvent.cs
+++ b/Runtime/Transition/TransitionByEvent.cs
@@ -23,7 +23,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit)) 
           {
-            sourceUnit.BaseGraph.StartState(targetUnit);
+            sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -37,7 +37,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit)) 
             {
-              sourceUnit.BaseGraph.StartState(targetUnit);
+              sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -59,7 +59,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit) && predicate(@event)) 
           {
-            sourceUnit.BaseGraph.StartState(targetUnit);
+            sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -73,7 +73,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit) && predicate(@event)) 
             {
-              sourceUnit.BaseGraph.StartState(targetUnit);
+              sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -95,7 +95,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit)) 
           {
-            sourceUnit.BaseGraph.StartState(targetUnit);
+            sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -109,7 +109,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit)) 
             {
-              sourceUnit.BaseGraph.StartState(targetUnit);
+              sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -132,7 +132,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit) && predicate(@event)) 
           {
-            sourceUnit.BaseGraph.StartState(targetUnit);
+            sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -146,7 +146,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (sourceUnit.BaseGraph != null && sourceUnit.BaseGraph.IsUnitActive(sourceUnit) && predicate(@event)) 
             {
-              sourceUnit.BaseGraph.StartState(targetUnit);
+              sourceUnit.BaseGraph.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -166,7 +166,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (graphContext.IsGraphActive) 
           {
-            graphContext.StartState(targetUnit);
+            graphContext.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -180,7 +180,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (graphContext.IsGraphActive) 
             {
-              graphContext.StartState(targetUnit);
+              graphContext.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -201,7 +201,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (graphContext.IsGraphActive && predicate(@event)) 
           {
-            graphContext.StartState(targetUnit);
+            graphContext.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -215,7 +215,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (graphContext.IsGraphActive && predicate(@event)) 
             {
-              graphContext.StartState(targetUnit);
+              graphContext.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -236,7 +236,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (graphContext.IsGraphActive) 
           {
-            graphContext.StartState(targetUnit);
+            graphContext.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -250,7 +250,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (graphContext.IsGraphActive) 
             {
-              graphContext.StartState(targetUnit);
+              graphContext.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );
@@ -272,7 +272,7 @@ namespace Nopnag.StateMachineLib.Transition
         {
           if (graphContext.IsGraphActive && predicate(@event)) 
           {
-            graphContext.StartState(targetUnit);
+            graphContext.StartState(targetUnit, @event.RaiseUniqueId);
           }
         }
       );
@@ -286,7 +286,7 @@ namespace Nopnag.StateMachineLib.Transition
           {
             if (graphContext.IsGraphActive && predicate(@event)) 
             {
-              graphContext.StartState(targetUnit);
+              graphContext.StartState(targetUnit, @event.RaiseUniqueId);
             }
           }
         );


### PR DESCRIPTION
## 🐛 Fix: Prevent Event Transition Chaining

### Problem
When multiple state transitions were configured to trigger on the same event type, raising the event once would cause a chain reaction, transitioning through multiple states in a single event raise cycle.

**Example:**
```csharp
(stateA > stateB).On<TestEventA>();
(stateB > stateC).On<TestEventA>();
(stateC > stateD).On<TestEventA>();

EventBus<TestEventA>.Raise(new TestEventA()); // From stateA
// ❌ Before: A→B→C→D (all in one raise)
// ✅ After:  A→B only
```

### Solution
Implemented a `RaiseUniqueId` tracking mechanism to prevent the same event instance from causing multiple consecutive transitions:

1. **Added `_currentStateEntryRaiseId` to `StateGraph`**: Tracks which event instance caused entry into the current state
2. **Modified `StartState()` method**: Accepts optional `raiseUniqueId` parameter and blocks transitions if the same event that entered a state tries to exit it
3. **Updated all `TransitionByEvent.Connect()` methods**: Pass `event.RaiseUniqueId` to enable tracking

### How It Works
- Each `BusEvent` instance gets a unique `RaiseUniqueId` when raised
- When an event triggers a transition (e.g., StateA → StateB), the ID is stored
- If the same event tries to trigger another transition from StateB, it's blocked
- A **new** event raise (with different `RaiseUniqueId`) can trigger transitions normally

### Changes
- ✅ `Runtime/StateGraph.cs`: Added tracking field and blocking logic
- ✅ `Runtime/Transition/TransitionByEvent.cs`: Updated all 8 Connect() overloads
- ✅ `Tests/StateMachineTests.cs`: Added 2 comprehensive tests

### Tests Added
1. **`EventTransition_OnlyActiveStateTransitions_NotChained`**  
   Verifies that only the active state's transition fires, preventing chain reactions

2. **`EventTransition_SecondEventRaise_AllowsTransition`**  
   Confirms that subsequent event raises (new instances) work correctly

### Breaking Changes
None - this is a bug fix that maintains backward compatibility. Non-event transitions continue to work unchanged.

### Additional Notes
- The anti-chaining mechanism only applies within a single event raise cycle
- Regular transitions (time-based, condition-based) are unaffected
- This fix ensures immediate, deterministic behavior as required